### PR TITLE
Adding Testcontainers for DevMode and integration tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-	id("org.springframework.boot") version "3.0.6"
+	id("org.springframework.boot") version "3.1.1"
 	id("io.spring.dependency-management") version "1.1.0"
 	kotlin("jvm") version "1.7.22"
 	kotlin("plugin.spring") version "1.7.22"
@@ -25,11 +25,14 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("org.springframework.boot:spring-boot-starter-data-mongodb:3.0.7")
+	implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
     compileOnly("org.projectlombok:lombok")
-	developmentOnly("org.springframework.boot:spring-boot-devtools")
 	annotationProcessor("org.projectlombok:lombok")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	testImplementation("org.springframework.boot:spring-boot-devtools")
+	testImplementation("org.springframework.boot:spring-boot-testcontainers")
+	testImplementation("org.testcontainers:junit-jupiter")
+	testImplementation("org.testcontainers:mongodb")
 }
 
 tasks.withType<KotlinCompile> {

--- a/service.rest
+++ b/service.rest
@@ -1,0 +1,9 @@
+POST http://localhost:8080/environments
+Content-Type: application/json
+
+{
+  "name": "asasdasd",
+  "description": "local environment"
+}
+
+###

--- a/src/test/kotlin/com/codingiscaring/envmanagerbackend/EnvironmentServiceTest.kt
+++ b/src/test/kotlin/com/codingiscaring/envmanagerbackend/EnvironmentServiceTest.kt
@@ -1,0 +1,51 @@
+package com.codingiscaring.envmanagerbackend
+
+import com.codingiscaring.envmanagerbackend.models.Environment
+import com.codingiscaring.envmanagerbackend.services.BaseRepository
+import com.codingiscaring.envmanagerbackend.services.EnvironmentService
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.testcontainers.containers.MongoDBContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.shaded.com.github.dockerjava.core.dockerfile.DockerfileStatement.Env
+import org.testcontainers.utility.DockerImageName
+
+@Testcontainers
+@DataMongoTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class EnvironmentServiceTest {
+    @Autowired
+    lateinit var repository: BaseRepository
+
+    lateinit var environmentService: EnvironmentService
+
+    companion object {
+        @ServiceConnection
+        @Container
+        @JvmStatic
+        val mongoContainer = MongoDBContainer(DockerImageName.parse("mongo:latest"))
+
+        init {
+            mongoContainer.start()
+        }
+    }
+
+    @BeforeAll
+    fun setup() {
+        environmentService = EnvironmentService(repository)
+    }
+
+    @Test
+    fun shouldStoreAnEnvironment() {
+        val environment = Environment("local", "local environment")
+        environmentService.create(environment)
+
+        assert(repository.count() == 1L, { "It should have one environment saved" })
+    }
+}

--- a/src/test/kotlin/com/codingiscaring/envmanagerbackend/RunEnvManager.kt
+++ b/src/test/kotlin/com/codingiscaring/envmanagerbackend/RunEnvManager.kt
@@ -1,0 +1,28 @@
+package com.codingiscaring.envmanagerbackend
+
+import org.springframework.boot.devtools.restart.RestartScope
+import org.springframework.boot.fromApplication
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.boot.with
+import org.springframework.context.annotation.Bean
+import org.testcontainers.containers.MongoDBContainer
+import org.testcontainers.utility.DockerImageName
+
+fun main(args: Array<String>) {
+    fromApplication<EnvManagerBackendApplication>()
+            .with(Configuration::class)
+            .run(*args)
+}
+
+@TestConfiguration(proxyBeanMethods = false)
+class Configuration {
+
+    @Bean
+    @RestartScope
+    @ServiceConnection
+    fun mongoContainer(): MongoDBContainer {
+        return MongoDBContainer(DockerImageName.parse("mongo:latest"))
+                .withReuse(true)
+    }
+}


### PR DESCRIPTION
I added Testcontainers library and configured to use the new capabilities of Spring Boot 3.1 that leverages the integration for DevMode.

- Now, you can start the whole project in local without needing to start Docker yourself with `./gradlew bootTestRun`. It starts the docker dependencies, in your case Mongo, and stop it automatically
- You can run the integration test without needing to have a local mongo running in your machine, it starts the MongoContainer when it needs it, and stop it when the test finishes. See `EnvironmentServiceTest` as an example.


I hope it helps! I learned a little of Kotlin today doing this PR! :laughing:  